### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     keywords="honeywell lyric thermostat",
     author="Aidan Timson (Timmo)",
     author_email="contact@timmo.xyz",
+    license="MIT",
     url="https://github.com/timmo001/aiolyric",
     packages=find_packages(exclude=["tests", "generator"]),
     install_requires=["aiohttp>=3.7.3"],


### PR DESCRIPTION
Allow third-party tools (e. g., PyPI or `pyp2rpm`) to get the license details in a simple way.