### PR TITLE
Fixing Typo to correctly set temperature in cool mode

### DIFF
--- a/aiolyric/__init__.py
+++ b/aiolyric/__init__.py
@@ -92,7 +92,7 @@ class Lyric(LyricBase):
         else:
             data["heatSetpoint"] = device.changeableValues.heatSetpoint
         if coolSetpoint is not None:
-            data["coolSetpoint"] = heatSetpoint
+            data["coolSetpoint"] = coolSetpoint
         else:
             data["coolSetpoint"] = device.changeableValues.coolSetpoint
 


### PR DESCRIPTION
Fixing typo to correctly set tempearture in Cool mode.

# Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

## Checklist

<!-- Remember! You can check these boxes later after posting your PR -->

- [ ] Change has been tested and works on my device(s).

<!-- All other checks are handled by the CI server as preflight checks.
     Make sure to fix any errors found.
     Your PR will not be merged if fixable errors are not resolved -->

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
