### PR TITLE
Drop loop kwarg from async_timeout.timeout

### DIFF
--- a/aiolyric/client/__init__.py
+++ b/aiolyric/client/__init__.py
@@ -44,7 +44,7 @@ class LyricClient(LyricBase):
         headers["Authorization"] = f"Bearer {access_token}"
         headers["Content-Type"] = "application/json"
 
-        async with async_timeout.timeout(20, loop=get_event_loop()):
+        async with async_timeout.timeout(20):
             response: ClientResponse = await self._session.request(
                 method,
                 url,


### PR DESCRIPTION
- async_timeout 4.0.0 drops the loop= kwarg and will fail if its passed

