### PR TITLE
Fix fan object classes

### DIFF
--- a/aiolyric/__init__.py
+++ b/aiolyric/__init__.py
@@ -139,7 +139,7 @@ class Lyric(LyricBase):
         if mode is not None:
             data["mode"] = mode
         else:
-            data["mode"] = device.fanMode
+            data["mode"] = device.settings.fan.changeableValues.mode
 
         self.logger.debug(data)
 

--- a/aiolyric/objects/device.py
+++ b/aiolyric/objects/device.py
@@ -63,12 +63,20 @@ class SettingsSpecialmode(LyricBase):
     @property
     def _(self):
         return None
-
+        
+class SettingsFanChangeableValues(LyricBase):
+    @property
+    def mode(self):
+        return self.attributes.get("mode", {})
+        
 class SettingsFan(LyricBase):
     @property
-    def fan(self):
-        return self.atributes.get("fan", {})
+    def allowedModes(self):
+        return self.attributes.get("allowedModes", {})
         
+    @property
+    def changeableValues(self):
+        return SettingsFanChangeableValues(self.attributes.get("changeableValues", {}))
 
 class Settings(LyricBase):
     @property
@@ -88,17 +96,9 @@ class Settings(LyricBase):
         return self.attributes.get("devicePairingEnabled", True)
 
     @property
-    def fanModes(self):
-        return SettingsFan(self.attributes.get("allowedModes", []))
-
-    @property
-    def fanChangeableValues(self):
-        return SettingsFan(self.attributes.get("changeableValues", {}))
+    def fan(self):
+        return SettingsFan(self.attributes.get("fan", {}))
     
-    @property
-    def fanMode(self):
-        return fanChangeableValues(self.attributes.get("mode", None))
-
 
 class Devicesettings(LyricBase):
     @property


### PR DESCRIPTION
# Proposed Changes
It appeared the updates from commit #28 didn't correctly map to the fan data in settings. This update makes it consistent with the API response for settings.fan
https://developer.honeywellhome.com/lyric/apis/get/devices/thermostats/%7BdeviceId%7D-0

## Related Issues
#28 

## Checklist
- [ x] Change has been tested and works on my device(s).

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
