### PR TITLE
Fix type of `rooms_dict` property

### DIFF
--- a/aiolyric/__init__.py
+++ b/aiolyric/__init__.py
@@ -48,7 +48,7 @@ class Lyric(LyricBase):
         return self._locations_dict
 
     @property
-    def rooms_dict(self) -> dict[str, LyricRoom]:
+    def rooms_dict(self) -> dict[str, dict[str, LyricRoom]]:
         return self._rooms_dict
 
     async def get_devices(


### PR DESCRIPTION
# Proposed Changes
Resolves https://github.com/timmo001/aiolyric/issues/67

The `_rooms_dict` member is a nested dictionary keyed by mac ID, then room ID, but the `rooms_dict` property that wraps it claims to return a type of `dict[str, LyricRoom]`. This corrects the type signature.

## Related Issues

* Discovered this issue while implementing https://github.com/home-assistant/core/pull/104956. That PR currently works around this issue by using `typing.cast`.

## Checklist

<!-- Remember! You can check these boxes later after posting your PR -->

- [x] Change has been tested and works on my device(s).

<!-- All other checks are handled by the CI server as preflight checks.
     Make sure to fix any errors found.
     Your PR will not be merged if fixable errors are not resolved -->

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
