### PR TITLE
Rename LyricAccessories to LyricAccessory

### DIFF
--- a/aiolyric/_version.py
+++ b/aiolyric/_version.py
@@ -7,5 +7,5 @@ Provides aiolyric version information.
 
 from incremental import Version
 
-__version__ = Version("aiolyric", 2, 0, 2)
+__version__ = Version("aiolyric", 2, 0, 1, dev=0)
 __all__ = ["__version__"]

--- a/aiolyric/_version.py
+++ b/aiolyric/_version.py
@@ -7,5 +7,5 @@ Provides aiolyric version information.
 
 from incremental import Version
 
-__version__ = Version("aiolyric", 2, 0, 1, dev=0)
+__version__ = Version("aiolyric", 2, 0, 2)
 __all__ = ["__version__"]

--- a/aiolyric/objects/priority.py
+++ b/aiolyric/objects/priority.py
@@ -3,8 +3,8 @@
 from .base import LyricBaseObject
 
 
-class LyricAccessories(LyricBaseObject):
-    """Lyric accessories."""
+class LyricAccessory(LyricBaseObject):
+    """Lyric accessory."""
 
     @property
     def id(self):
@@ -73,7 +73,7 @@ class LyricRoom(LyricBaseObject):
     @property
     def accessories(self):
         """Get the list of accessories in the room."""
-        return [LyricAccessories(x) for x in self.attributes.get("accessories", [])]
+        return [LyricAccessory(x) for x in self.attributes.get("accessories", [])]
 
 
 class CurrentPriority(LyricBaseObject):


### PR DESCRIPTION
Properly reflect the object is a single accessory, not a collection of accessories.

[x] Unit tests pass locally
[x] ran `python -m incremental.update aiolyric --patch`

Let me know if this was an incorrect way to bump the version number.