### PR TITLE
Priority Update Endpoint

### DIFF
--- a/aiolyric/__init__.py
+++ b/aiolyric/__init__.py
@@ -192,3 +192,24 @@ class Lyric:
             f"{BASE_URL}/devices/thermostats/{device.device_id}/fan?apikey={self._client_id}&locationId={location.location_id}",
             json=data,
         )
+
+    async def update_priority(
+        self,
+        location: LyricLocation,
+        device: LyricDevice,
+        type: str,
+        rooms: list[int],
+    ) -> ClientResponse:
+        """Update Fan."""
+        self.logger.debug("Update Fan")
+
+        priority = {"priorityType": type, "selectedRooms": rooms}
+        
+        data = {"currentPriority": priority}
+
+        self.logger.debug(data)
+
+        return await self._client.post(
+            f"{BASE_URL}/devices/thermostats/{device.device_id}/priority?apikey={self._client_id}&locationId={location.location_id}",
+            json=data,
+        )


### PR DESCRIPTION
I would like to be able to use the API to set the room priority on the thermostat.

`https://api.honeywellhome.com/v2/devices/thermostats/{deviceId}/priority`

`{
    "currentPriority": {
        "priorityType": "PickARoom",
        "selectedRooms": [
            0,
            1
        ]
    }
}`

currentPriority.priorityType	String	Set the desired priority type ('PickARoom', 'FollowMe', 'WholeHouse')

currentPriority.selectedRooms	Array	Comma separated list of numbers of the rooms to use in the priority setting