### PR TITLE
Store LyricPriority object in priorities_dict

### DIFF
--- a/aiolyric/__init__.py
+++ b/aiolyric/__init__.py
@@ -28,6 +28,7 @@ class Lyric:
         self._devices_dict: dict = {}
         self._locations: list[LyricLocation] = []
         self._locations_dict: dict = {}
+        self._priorities_dict: dict[str, LyricPriority] = {}
         self._rooms_dict: dict = {}
 
     @property
@@ -54,6 +55,11 @@ class Lyric:
     def locations_dict(self) -> dict:
         """Return the locations dict."""
         return self._locations_dict
+
+    @property
+    def priorities_dict(self) -> dict[str, LyricPriority]:
+        """Return the priorities dict, keyed by device MAC address."""
+        return self._priorities_dict
 
     @property
     def rooms_dict(self) -> dict[str, dict[str, LyricRoom]]:
@@ -105,6 +111,7 @@ class Lyric:
 
         # device id in the priority payload refers to the mac address of the device
         mac_id = priority.device_id
+        self._priorities_dict[mac_id] = priority
         self._rooms_dict[mac_id] = {}
 
         # add each room to the room dictionary. Rooms contain motion, temp, and humidity averages for all accessories in a room


### PR DESCRIPTION
`get_thermostat_rooms` currently parses the priority API response but only stores the room objects, discarding the `LyricPriority` wrapper. This means consumers can't read `current_priority.priority_type` or `current_priority.selected_rooms` without making another API call.

This adds a `priorities_dict` property (keyed by device MAC, same as `rooms_dict`) that stores the full `LyricPriority` object.

Needed for an upcoming Home Assistant PR that adds a select entity to control room priority — it needs to read the current priority type and selected rooms from the coordinator data.

Related: #134 (update_priority fix)